### PR TITLE
Fix missing phone list in WebApp.

### DIFF
--- a/src/main/webapp/assets/js/controllers.js
+++ b/src/main/webapp/assets/js/controllers.js
@@ -6,7 +6,7 @@ var phonecatApp = angular.module('phonecatApp', []);
 
 phonecatApp.controller('PhoneListCtrl', function($scope, $http) {
   $http.get('phone/list').success(function(data) {
-    $scope.phones = data.phone;
+    $scope.phones = data;
   });
 
   $scope.orderProp = 'age';


### PR DESCRIPTION
Running starter project immediately after fork/clone displayed no phones in WebApp.  Debugging script showed that the pone list is returned in `data`, not `data.phone`.